### PR TITLE
Definitives Programm und Anmeldung Anwendertreffen 2025 de und fr

### DIFF
--- a/_posts/2025-05-14-anwendertreffen-anmeldung-offen-2025.md
+++ b/_posts/2025-05-14-anwendertreffen-anmeldung-offen-2025.md
@@ -1,0 +1,24 @@
+---
+lang: de
+excerpt: >-
+  Jetzt anmelden: das 17. Anwendertreffen 2025 findet am Dienstag, 17. Juni in Bern statt.
+title: Anwendertreffen am 17. Juni 2025 in Bern
+---
+
+# {{ page.title }}
+
+*Veröffentlicht am {{ page.date | date: "%d. %b %Y"}}*
+
+Das definitive Programm für den Anwendertag QGIS-CH vom 17. Juni 2025 in Bern steht und das Anmeldeformular ist freigeschaltet ist!
+
+[Programm- und Anmeldeseite des Treffens]({% link de/anwendertreffen/anwendertreffen-2025.md %}). 
+
+Wir hoffen auf eine rege Teilnahme eurerseits und freuen uns euch vor Ort begrüssen zu dürfen.
+
+Zögert nicht, die Infos an Interessierte auch ausserhalb des Vereins weiterzuleiten.
+
+Achtung: 
+Der Anlass findet diesmal in der Unitobler in Bern statt  (siehe Plan online) – diese liegt ebenfalls an der Langstrasse aber etwa 500m weiter vom Bahnhof entfernt als die Uni S.
+
+
+

--- a/_posts/2025-05-14-anwendertreffen-anmeldung-offen-2025.md
+++ b/_posts/2025-05-14-anwendertreffen-anmeldung-offen-2025.md
@@ -18,7 +18,7 @@ Wir hoffen auf eine rege Teilnahme eurerseits und freuen uns euch vor Ort begrü
 Zögert nicht, die Infos an Interessierte auch ausserhalb des Vereins weiterzuleiten.
 
 Achtung: 
-Der Anlass findet diesmal in der Unitobler in Bern statt  (siehe Plan online) – diese liegt ebenfalls an der Langstrasse aber etwa 500m weiter vom Bahnhof entfernt als die Uni S.
+Der Anlass findet diesmal in der Unitobler in Bern statt  (siehe Plan online) – diese liegt ebenfalls an der Länggasse aber etwa 500m weiter vom Bahnhof entfernt als die UniS.
 
 
 

--- a/_posts/2025-05-14-reunion-des-utilisateurs-registration-ouverte-2025.md
+++ b/_posts/2025-05-14-reunion-des-utilisateurs-registration-ouverte-2025.md
@@ -16,4 +16,4 @@ Plus d'informations et registration sur la [page du programme de la rencontre]({
 N’hésitez pas à transmettre les informations aux intéressés, même en dehors de l’association.
 
 Attention :
-Cette fois-ci l’évènement a lieu à l’Unitobler  Berne (voir plan en ligne) qui se situe également à la Langstrasse, mais environ 500m plus loin de la gare que l’habituelle Uni S.
+Cette fois-ci l’évènement a lieu à l’Unitobler  Berne (voir plan en ligne) qui se situe également à la Länggasse, mais environ 500m plus loin de la gare que l’habituelle UniS.

--- a/_posts/2025-05-14-reunion-des-utilisateurs-registration-ouverte-2025.md
+++ b/_posts/2025-05-14-reunion-des-utilisateurs-registration-ouverte-2025.md
@@ -1,0 +1,19 @@
+---
+lang: fr
+excerpt: >-
+  Registrez maintenant: la 17e réunion des utilisateurs 2025 aura lieu le mardi 17 juin à Berne.
+title: Réunion des utilisateurs le 17 juin 2025 à Berne
+---
+
+# {{ page.title }}
+
+*Publié le {{ page.date | date: "%d. %b %Y"}}*
+
+Le programme définitive de la journée des utilisateurs QGIS-CH du 17 juin 2025 à Berne est en ligne et que les inscriptions sont ouvertes ! Nous vous réjouissons d’ores et déjà de vous accueillir sur place.
+
+Plus d'informations et registration sur la [page du programme de la rencontre]({% link fr/reunions/reunion-utilisateurs-2025.md %}).
+
+N’hésitez pas à transmettre les informations aux intéressés, même en dehors de l’association.
+
+Attention :
+Cette fois-ci l’évènement a lieu à l’Unitobler  Berne (voir plan en ligne) qui se situe également à la Langstrasse, mais environ 500m plus loin de la gare que l’habituelle Uni S.


### PR DESCRIPTION
@webrian Ich habe mal getestet wie ein Post geht - ich habe gesehen, dass die Info dass man sich anmelden kann noch nicht online ist.

Dies im Hinblick auch auf den Journee romand de la géoinformation, wo noch eine gemeinsame Landing page für QGIS und TEKSI fehlt.